### PR TITLE
Adding the link to SageMaker SSH Helper library

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -11,6 +11,7 @@
 - [Blog] [External] [Building machine learning models in the cloud: A paradigm shift](https://towardsdatascience.com/building-machine-learning-models-in-the-cloud-a-paradigm-shift-ff7dbbc39312)
 - [Blog] [Host VS code-server on Amazon SageMaker](https://aws.amazon.com/blogs/machine-learning/host-code-server-on-amazon-sagemaker/)
 - [Docs] [External] [Using RStudio on SageMaker](https://www.rstudio.com/sagemaker/)
+- [Code] [SageMaker SSH Helper](https://github.com/aws-samples/sagemaker-ssh-helper) - a library to connect into SageMaker with AWS Systems Manager / SSH and to integrate with local PyCharm / VSCode
 
 ### Architecture Best Practices
 - [Docs] [Architecture Best Practices for Machine Learning](https://aws.amazon.com/architecture/machine-learning/)


### PR DESCRIPTION
# Description

[SageMaker SSH Helper](https://github.com/aws-samples/sagemaker-ssh-helper) is a library that helps you to securely connect to Amazon SageMaker's training jobs, processing jobs, realtime inference endpoints, and SageMaker Studio notebook containers for fast interactive experimentation, remote debugging, and advanced troubleshooting.

The two most common scenarios for the library are:

1. Open a terminal session into a container running in SageMaker to diagnose a stuck training job, use CLI commands like nvidia-smi, or iteratively fix and re-execute your training script within seconds.
2. Remote debug a code running in SageMaker from your local favorite IDE like PyCharm Professional Edition or Visual Studio Code.

Other scenarios include but not limited to connecting to a remote Jupyter Notebook in SageMaker Studio from your IDE or start a VNC session to SageMaker Studio to run GUI apps.

## Focus Area

Please select the area where you want to include the content.

- [X] Getting Started
- [ ] Building ML Models
- [ ] Deploying ML Models
- [ ] MLOps
- [ ] Low Code/ No Code ML
- [ ] ML Governance
- [ ] Responsible AI
- [ ] Audio
- [ ] Computer Vision
- [ ] NLP
- [ ] R
- [ ] Learning SageMaker

## Content Type

- [ ] Blog
- [X] Code
- [ ] Docs
- [ ] Video
- [ ] Workshop

## External Content

Content included in the list should be marked as external if it is not officially provided by Amazon Web Services

- [ ] Yes
- [X] No